### PR TITLE
Require access token for user deletion endpoint

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -61,7 +61,7 @@ function updateHeaders(request, accessToken) {
 }
 
 function needsAccessToken(pathname) {
-  return (/^\/*auth\/(?!logout).*$/i.test(pathname) === false && /api\/v1\/helpers\//i.test(pathname) === false
+  return (/^\/*auth\/(?!logout|users).*$/i.test(pathname) === false && /api\/v1\/helpers\//i.test(pathname) === false
   );
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -61,7 +61,7 @@ function updateHeaders(request, accessToken) {
 }
 
 function needsAccessToken(pathname) {
-  return (/^\/*auth\/(?!logout|users\/[0-9a-f]{24}).*$/i.test(pathname) === false && /api\/v1\/helpers\//i.test(pathname) === false
+  return (/^\/*auth\/(?!logout).*$/i.test(pathname) === false && /api\/v1\/helpers\//i.test(pathname) === false
   );
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -61,7 +61,7 @@ function updateHeaders(request, accessToken) {
 }
 
 function needsAccessToken(pathname) {
-  return (/^\/*auth\/(?!logout|users).*$/i.test(pathname) === false && /api\/v1\/helpers\//i.test(pathname) === false
+  return (/^\/*auth\/(?!logout|users\/[0-9a-f]{24}).*$/i.test(pathname) === false && /api\/v1\/helpers\//i.test(pathname) === false
   );
 }
 

--- a/interceptor/accessToken.js
+++ b/interceptor/accessToken.js
@@ -11,7 +11,7 @@ function updateHeaders (request, accessToken) {
 }
 
 function needsAccessToken (pathname) {
-  return (/^\/*auth\/(?!logout).*$/i).test(pathname) === false &&
+  return (/^\/*auth\/(?!logout|users\/[0-9a-f]{24}).*$/i).test(pathname) === false &&
     (/api\/v1\/helpers\//i).test(pathname) === false
 }
 


### PR DESCRIPTION
This PR implements requiring an access token for user deletion endpoint `[DELETE] /auth/users/:id`